### PR TITLE
COMOPS-908: Updating compatibility with the BIC doc generator

### DIFF
--- a/src/Analyzer/AbstractCodeAnalyzer.php
+++ b/src/Analyzer/AbstractCodeAnalyzer.php
@@ -244,7 +244,7 @@ abstract class AbstractCodeAnalyzer implements AnalyzerInterface
      * @param string $context
      * @param string $fileBefore
      * @param string $fileAfter
-     * @return array
+     * @return AbstractCodeAnalyzer[]
      */
     protected function getContentAnalyzers($context, $fileBefore, $fileAfter)
     {

--- a/src/Analyzer/ClassAnalyzer.php
+++ b/src/Analyzer/ClassAnalyzer.php
@@ -108,7 +108,6 @@ class ClassAnalyzer extends AbstractCodeAnalyzer
             $classAfter = $afterNameMap[$key];
 
             if ($classBefore !== $classAfter) {
-                /** @var AnalyzerInterface[] $analyzers */
                 $analyzers = $this->getContentAnalyzers(static::CONTEXT, $fileBefore, $fileAfter);
 
                 foreach ($analyzers as $analyzer) {
@@ -125,7 +124,7 @@ class ClassAnalyzer extends AbstractCodeAnalyzer
      * @param string $context
      * @param string $fileBefore
      * @param string $fileAfter
-     * @return array
+     * @return AbstractCodeAnalyzer[]
      */
     protected function getContentAnalyzers($context, $fileBefore, $fileAfter)
     {
@@ -139,7 +138,6 @@ class ClassAnalyzer extends AbstractCodeAnalyzer
             new ClassTraitAnalyzer($context, $fileBefore, $fileAfter),
         ];
     }
-
 
     /**
      * Get the class node registry

--- a/src/Analyzer/InterfaceAnalyzer.php
+++ b/src/Analyzer/InterfaceAnalyzer.php
@@ -118,7 +118,6 @@ class InterfaceAnalyzer extends AbstractCodeAnalyzer
             $interfaceAfter = $afterNameMap[$key];
 
             if ($interfaceBefore !== $interfaceAfter) {
-                /** @var AnalyzerInterface[] $analyzers */
                 $analyzers = $this->getContentAnalyzers(static::CONTEXT, $fileBefore, $fileAfter);
 
                 foreach ($analyzers as $analyzer) {
@@ -135,7 +134,7 @@ class InterfaceAnalyzer extends AbstractCodeAnalyzer
      * @param string $context
      * @param string $fileBefore
      * @param string $fileAfter
-     * @return array
+     * @return AbstractCodeAnalyzer[]
      */
     protected function getContentAnalyzers($context, $fileBefore, $fileAfter)
     {
@@ -146,6 +145,4 @@ class InterfaceAnalyzer extends AbstractCodeAnalyzer
             new InterfaceExtendsAnalyzer($context, $fileBefore, $fileAfter)
         ];
     }
-
-
 }

--- a/src/Analyzer/TraitAnalyzer.php
+++ b/src/Analyzer/TraitAnalyzer.php
@@ -115,8 +115,6 @@ class TraitAnalyzer extends AbstractCodeAnalyzer
             if ($traitBefore !== $traitAfter) {
                 $fileBefore  = $this->getFileName($registryBefore, $traitName);
                 $fileAfter   = $this->getFileName($registryAfter, $traitName);
-
-                /** @var AbstractCodeAnalyzer[] $analyzers */
                 $analyzers = $this->getContentAnalyzers(static::CONTEXT, $fileBefore, $fileAfter);
 
                 foreach ($analyzers as $analyzer) {
@@ -133,12 +131,10 @@ class TraitAnalyzer extends AbstractCodeAnalyzer
      * @param string $context
      * @param string $fileBefore
      * @param string $fileAfter
-     * @return array
+     * @return AbstractCodeAnalyzer[]
      */
     protected function getContentAnalyzers($context, $fileBefore, $fileAfter)
     {
         return [new ClassMethodAnalyzer($context, $fileBefore, $fileAfter)];
     }
-
-
 }

--- a/src/DbSchemaReport.php
+++ b/src/DbSchemaReport.php
@@ -11,19 +11,6 @@ use PHPSemVerChecker\SemanticVersioning\Level;
 
 class DbSchemaReport extends ReportAlias
 {
-    public static $contexts = [
-        'class',
-        'function',
-        'interface',
-        'trait',
-        'database',
-        'di',
-        'layout',
-        'system',
-        'xsd',
-        'less'
-    ];
-
     /**
      * Report constructor.
      */
@@ -31,8 +18,11 @@ class DbSchemaReport extends ReportAlias
     {
         $levels = array_fill_keys(Level::asList(), []);
         parent::__construct();
-        foreach (static::$contexts as $context) {
-            $this->differences[$context] = $levels;
-        }
+        $this->differences['database'] = $levels;
+        $this->differences['di'] = $levels;
+        $this->differences['layout'] = $levels;
+        $this->differences['system'] = $levels;
+        $this->differences['xsd'] = $levels;
+        $this->differences['less'] = $levels;
     }
 }

--- a/src/MergedReport.php
+++ b/src/MergedReport.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\SemanticVersionChecker;
+
+use PHPSemVerChecker\Report\Report;
+
+class MergedReport extends Report
+{
+    /**
+     * Merges with the given report including any non-standard contexts
+     *
+     * @param Report $report
+     * @return $this
+     */
+    public function merge(Report $report)
+    {
+        foreach ($report->differences as $context => $levels) {
+            if (!key_exists($context, $this->differences)) {
+                $this->differences[$context] = $levels;
+            } else {
+                foreach ($levels as $level => $differences) {
+                    $this->differences[$context][$level] = array_merge(
+                        $this->differences[$context][$level],
+                        $differences
+                    );
+                }
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/ReportBuilder.php
+++ b/src/ReportBuilder.php
@@ -44,9 +44,9 @@ class ReportBuilder
 
     /**
      * Define analyzer factory list for the different report types.
-     * @var array
+     * @var string[]
      */
-    private $analyzerList = [
+    private $analyzerFactoryClasses = [
         ReportTypes::API        => AnalyzerFactory::class,
         ReportTypes::ALL        => NonApiAnalyzerFactory::class,
         ReportTypes::DB_SCHEMA  => DbSchemaAnalyzerFactory::class,
@@ -121,11 +121,11 @@ class ReportBuilder
     /**
      * Get the mapping of report type -> analyzer factory
      *
-     * @return array
+     * @return string[]
      */
-    protected function getAnalyzerFactories()
+    protected function getAnalyzerFactoryClasses()
     {
-        return $this->analyzerList;
+        return $this->analyzerFactoryClasses;
     }
 
     /**
@@ -171,7 +171,7 @@ class ReportBuilder
         /**
          * @var AnalyzerFactoryInterface $factory
          */
-        foreach ($this->getAnalyzerFactories() as $reportType => $factory) {
+        foreach ($this->getAnalyzerFactoryClasses() as $reportType => $factory) {
             /** @var AnalyzerInterface $analyzer */
             $analyzer = (new $factory())->create($dependencyMap);
             $tmpReport = $analyzer->analyze(

--- a/src/Reporter/BreakingChangeTableReporter.php
+++ b/src/Reporter/BreakingChangeTableReporter.php
@@ -7,7 +7,6 @@
 // @codingStandardsIgnoreFile
 namespace Magento\SemanticVersionChecker\Reporter;
 
-use Magento\SemanticVersionChecker\DbSchemaReport;
 use PHPSemVerChecker\Report\Report;
 use PHPSemVerChecker\SemanticVersioning\Level;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -52,14 +51,15 @@ class BreakingChangeTableReporter extends TableReporter
      */
     public function output(OutputInterface $output)
     {
-        $contexts = DbSchemaReport::$contexts;
+        $reportContexts = array_keys($this->report->getDifferences());
+        $membershipContexts = array_keys($this->membershipReport->getDifferences());
 
-        foreach ($contexts as $context) {
+        foreach ($reportContexts as $context) {
             $header = static::formatSectionHeader($this->targetFile, $context, 'breaking-change');
             $this->outputChangeReport($output, $this->report, $context, $header);
         }
 
-        foreach ($contexts as $context) {
+        foreach ($membershipContexts as $context) {
             $header = static::formatSectionHeader($this->targetFile, $context, 'api-membership');
             $this->outputChangeReport($output, $this->membershipReport, $context, $header);
         }

--- a/tests/Unit/MergedReportTest.php
+++ b/tests/Unit/MergedReportTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\SemanticVersionChecker\Test\Unit;
+
+use Magento\SemanticVersionChecker\InjectableReport;
+use Magento\SemanticVersionChecker\MergedReport;
+use Magento\SemanticVersionChecker\Operation\ClassConstantRemoved;
+use Magento\SemanticVersionChecker\Operation\ClassConstructorOptionalParameterAdded;
+use Magento\SemanticVersionChecker\Operation\ClassExtendsAdded;
+use Magento\SemanticVersionChecker\Operation\ClassImplementsAdded;
+use Magento\SemanticVersionChecker\Operation\ClassMethodOptionalParameterAdded;
+use Magento\SemanticVersionChecker\Operation\ClassTraitAdded;
+use Magento\SemanticVersionChecker\Operation\DropForeignKey;
+use Magento\SemanticVersionChecker\Operation\SystemXml\FieldAdded;
+use PHPSemVerChecker\Report\Report;
+use PHPSemVerChecker\SemanticVersioning\Level;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class MergedReportTest extends TestCase
+{
+    /**
+     * Verify that reports are properly merged including non-standard contexts
+     *
+     * @return void
+     */
+    public function testMergedChanges()
+    {
+        $diffsWithDatabase = [];
+        $diffsWithDatabase['class'][Level::PATCH] = [$this->createMock(ClassConstructorOptionalParameterAdded::class)];
+        $diffsWithDatabase['class'][Level::MINOR] = [
+            $this->createMock(ClassExtendsAdded::class),
+            $this->createMock(ClassMethodOptionalParameterAdded::class)
+        ];
+        $diffsWithDatabase['database'][Level::MAJOR] = [$this->createMock(DropForeignKey::class)];
+        $databaseReport = new InjectableReport($diffsWithDatabase);
+
+        $diffsWithXml = [];
+        $diffsWithXml['class'][Level::MAJOR] = [$this->createMock(ClassConstantRemoved::class)];
+        $diffsWithXml['class'][Level::MINOR] = [$this->createMock(ClassImplementsAdded::class)];
+        $diffsWithXml['xml'][Level::MINOR] = [$this->createMock(FieldAdded::class)];
+        $xmlReport = new InjectableReport($diffsWithXml);
+
+        /** @var MockObject|ClassTraitAdded $preMergeOperation */
+        $preMergeOperation = $this->createMock(ClassTraitAdded::class);
+        $preMergeOperation->expects($this->any())->method('getLevel')->willReturn(Level::MINOR);
+
+        $mergedReport = new MergedReport();
+        $mergedReport->addClass($preMergeOperation);
+        $mergedReport->merge($databaseReport);
+        $mergedReport->merge($xmlReport);
+
+        $mergedDiffs = $mergedReport->getDifferences();
+        $this->assertTrue(key_exists('database', $mergedDiffs));
+        $this->assertTrue(key_exists('xml', $mergedDiffs));
+        $this->assertTrue($this->hasAllDifferences($mergedReport, $databaseReport));
+        $this->assertTrue($this->hasAllDifferences($mergedReport, $xmlReport));
+        $this->assertTrue(array_search($preMergeOperation, $mergedDiffs['class'][Level::MINOR]) !== false);
+    }
+
+    /**
+     * Checks if a merged report contains all differences in another report
+
+     * @param Report $mergedReport
+     * @param Report $inputReport
+     * @return bool
+     */
+    private function hasAllDifferences($mergedReport, $inputReport)
+    {
+        $mergedDiffs = $mergedReport->getDifferences();
+        $inputDiffs = $inputReport->getDifferences();
+        foreach ($inputDiffs as $context => $levels) {
+            if (!key_exists($context, $mergedDiffs)) {
+                return false;
+            }
+            $mergedLevels = $mergedDiffs[$context];
+            foreach ($levels as $level => $operations) {
+                if (!key_exists($level, $mergedLevels)) {
+                    return false;
+                }
+                $mergedOperations = $mergedLevels[$level];
+                foreach ($operations as $operation) {
+                    if (array_search($operation, $mergedOperations) === false) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
# Description
### [COMOPS-908](https://jira.corp.magento.com/browse/COMOPS-908): BIC Doc Tool enhancements
* Made magento-semver more inheritance-friendly to allow the BIC Doc Generator tool to automatically pull in any new rules/analyzers added to magento-semver

## Manual testing scenarios

1. Run the [BIC Doc Generator job](https://bamboo.corp.magento.com/browse/MD23-PBC231) against this and the associated internal PR and examine the resulting PR in the magento/devdocs repo

## Contribution checklist

- [X] Pull request has a meaningful description of its purpose
- [X] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
