### PR TITLE
Detect when virtualTypes move elsewhere

### DIFF
--- a/dev/tests/Unit/Console/Command/CompareSourceCommandDiXmlTest.php
+++ b/dev/tests/Unit/Console/Command/CompareSourceCommandDiXmlTest.php
@@ -55,6 +55,22 @@ class CompareSourceCommandDiXmlTest extends AbstractTestCaseWithRegExp
                 ],
                 ''
             ],
+            'moved-to-app-etc' => [
+                $pathToFixtures . '/moved-to-app-etc/source-code-before',
+                $pathToFixtures . '/moved-to-app-etc/source-code-after',
+                [
+                    '#Suggested semantic versioning change: NONE#',
+                ],
+                'Patch change is detected.',
+            ],
+            'moved-to-another-module' => [
+                $pathToFixtures . '/moved-to-another-module/source-code-before',
+                $pathToFixtures . '/moved-to-another-module/source-code-after',
+                [
+                    '#Suggested semantic versioning change: NONE#',
+                ],
+                'Patch change is detected.',
+            ],
             'moved-to-global' => [
                 $pathToFixtures . '/moved-to-global/source-code-before',
                 $pathToFixtures . '/moved-to-global/source-code-after',

--- a/dev/tests/Unit/Console/Command/CompareSourceCommandTest/_files/di_xml/moved-to-another-module/source-code-after/Magento/AnotherTestModule/etc/di.xml
+++ b/dev/tests/Unit/Console/Command/CompareSourceCommandTest/_files/di_xml/moved-to-another-module/source-code-after/Magento/AnotherTestModule/etc/di.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- This file is in Magento_AnotherTestModule's etc/ directory -->
+
+    <!-- @api -->
+    <virtualType name="customCacheInstance" type="Magento\Framework\App\Cache" shared="true"/>
+    <!-- @api -->
+    <virtualType name="customCacheInstance2" type="Magento\Test" />
+    <!-- @api -->
+    <virtualType name="customCacheInstance3" type="Magento\Framework\Test2" shared="false"/>
+</config>

--- a/dev/tests/Unit/Console/Command/CompareSourceCommandTest/_files/di_xml/moved-to-another-module/source-code-before/Magento/TestModule/etc/di.xml
+++ b/dev/tests/Unit/Console/Command/CompareSourceCommandTest/_files/di_xml/moved-to-another-module/source-code-before/Magento/TestModule/etc/di.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- This file is in Magento_TestModule's etc/ directory -->
+
+    <!-- @api -->
+    <virtualType name="customCacheInstance" type="Magento\Framework\App\Cache" shared="true"/>
+    <!-- @api -->
+    <virtualType name="customCacheInstance2" type="Magento\Test" />
+    <!-- @api -->
+    <virtualType name="customCacheInstance3" type="Magento\Framework\Test2" shared="false"/>
+</config>

--- a/dev/tests/Unit/Console/Command/CompareSourceCommandTest/_files/di_xml/moved-to-app-etc/source-code-after/app/etc/di.xml
+++ b/dev/tests/Unit/Console/Command/CompareSourceCommandTest/_files/di_xml/moved-to-app-etc/source-code-after/app/etc/di.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- This file is in a the global app/etc/ directory -->
+
+    <!-- @api -->
+    <virtualType name="customCacheInstance" type="Magento\Framework\App\Cache" shared="true"/>
+    <!-- @api -->
+    <virtualType name="customCacheInstance2" type="Magento\Test" />
+    <!-- @api -->
+    <virtualType name="customCacheInstance3" type="Magento\Framework\Test2" shared="false"/>
+</config>

--- a/dev/tests/Unit/Console/Command/CompareSourceCommandTest/_files/di_xml/moved-to-app-etc/source-code-before/Magento/TestModule/etc/di.xml
+++ b/dev/tests/Unit/Console/Command/CompareSourceCommandTest/_files/di_xml/moved-to-app-etc/source-code-before/Magento/TestModule/etc/di.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- This file is in a module's etc/ directory -->
+
+    <!-- @api -->
+    <virtualType name="customCacheInstance" type="Magento\Framework\App\Cache" shared="true"/>
+    <!-- @api -->
+    <virtualType name="customCacheInstance2" type="Magento\Test" />
+    <!-- @api -->
+    <virtualType name="customCacheInstance3" type="Magento\Framework\Test2" shared="false"/>
+</config>

--- a/src/Analyzer/DiXml/VirtualTypeAnalyzer.php
+++ b/src/Analyzer/DiXml/VirtualTypeAnalyzer.php
@@ -67,6 +67,17 @@ class VirtualTypeAnalyzer implements AnalyzerInterface
                     continue;
                 }
 
+                foreach ($nodesAfter as $newModuleNodes) {
+                    foreach ($newModuleNodes as $nodeAfter) {
+                        if ($nodeBefore->getName() !== $nodeAfter->getName()) {
+                            continue;
+                        }
+
+                        $this->triggerNodeChange($nodeBefore, $nodeAfter, $fileBefore);
+                        continue 3;
+                    }
+                }
+
                 $operation = new VirtualTypeRemoved($fileBefore, $name);
                 $this->report->add('di', $operation);
             }

--- a/src/resources/application_includes.txt
+++ b/src/resources/application_includes.txt
@@ -1,4 +1,5 @@
 app/code
+app/etc
 lib/internal/Magento
 Inventory*
 Adobe*


### PR DESCRIPTION
# Description

While working on https://github.com/magento/magento2/pull/32690, it was noticed that a `virtualType` which is used in multiple modules (namely `shellBackground` used in both `Magento_Cron` and `Magento_MessageQueue`). Moving this to `app/etc/di.xml` where it belongs triggered an automated test failure from this tool. This pull request aims to handle this case as expected.

## Manual testing scenarios

Unit tests are included with this change. Without the code change, these unit tests fail.

## Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
