### PR TITLE
Add guard clause in Less Analyzer for Less imports of external files

### DIFF
--- a/src/Analyzer/Less/Analyzer.php
+++ b/src/Analyzer/Less/Analyzer.php
@@ -122,7 +122,7 @@ class Analyzer implements AnalyzerInterface
                 /** @var Less_Tree $node */
                 foreach ($content as $node) {
                     //skip comments
-                    if ($node instanceof Less_Tree_Comment) {
+                    if ($node instanceof Less_Tree_Comment || $node instanceof Less_Tree_Import) {
                         continue;
                     }
                     if (property_exists($node, 'name')) {


### PR DESCRIPTION
Related to https://github.com/magento/magento-semver/issues/73 - option 1, if you wish to see a more indepth writeup 

The Less Analyzer class cannot handle Less files that import css via `@import url()` as the object they convert into mean the $node->path->value is a Link_Tree_Quoted object and not a string castable value, so we ignore them as outside content is may not be relevant to the semver check. 