### PR TITLE
Update Less Analyzer to be able to handle imports of files

### DIFF
--- a/src/Analyzer/Less/Analyzer.php
+++ b/src/Analyzer/Less/Analyzer.php
@@ -130,7 +130,8 @@ class Analyzer implements AnalyzerInterface
                     } elseif (property_exists($node, 'type') && property_exists($node, 'path')) {
                         if ($node->path->value instanceof \Less_Tree_Quoted 
                             || property_exists($node->path->value, 'value')) 
-                        {                            $nodeKey = $node->type . ' with value: \'' . $node->path->value->value . '\'';
+                        {
+                            $nodeKey = $node->type . ' with value: \'' . $node->path->value->value . '\'';
                         } else {
                             $nodeKey = $node->type . ' with value: \'' . $node->path->value . '\'';
                         }

--- a/src/Analyzer/Less/Analyzer.php
+++ b/src/Analyzer/Less/Analyzer.php
@@ -128,8 +128,9 @@ class Analyzer implements AnalyzerInterface
                     if (property_exists($node, 'name')) {
                         $nodeKey = $node->name;
                     } elseif (property_exists($node, 'type') && property_exists($node, 'path')) {
-                        if ($node->path->value instanceof \Less_Tree_Quoted || property_exists($node->path->value, 'value')) {
-                            $nodeKey = $node->type . ' with value: \'' . $node->path->value->value . '\'';
+                        if ($node->path->value instanceof \Less_Tree_Quoted 
+                            || property_exists($node->path->value, 'value')) 
+                        {                            $nodeKey = $node->type . ' with value: \'' . $node->path->value->value . '\'';
                         } else {
                             $nodeKey = $node->type . ' with value: \'' . $node->path->value . '\'';
                         }

--- a/src/Analyzer/Less/Analyzer.php
+++ b/src/Analyzer/Less/Analyzer.php
@@ -128,9 +128,10 @@ class Analyzer implements AnalyzerInterface
                     if (property_exists($node, 'name')) {
                         $nodeKey = $node->name;
                     } elseif (property_exists($node, 'type') && property_exists($node, 'path')) {
-                        if ($node->path->value instanceof \Less_Tree_Quoted 
-                            || property_exists($node->path->value, 'value')) 
-                        {
+                        if (
+                            $node->path->value instanceof \Less_Tree_Quoted
+                            || property_exists($node->path->value, 'value')
+                        ) {
                             $nodeKey = $node->type . ' with value: \'' . $node->path->value->value . '\'';
                         } else {
                             $nodeKey = $node->type . ' with value: \'' . $node->path->value . '\'';

--- a/src/Analyzer/Less/Analyzer.php
+++ b/src/Analyzer/Less/Analyzer.php
@@ -128,7 +128,11 @@ class Analyzer implements AnalyzerInterface
                     if (property_exists($node, 'name')) {
                         $nodeKey = $node->name;
                     } elseif (property_exists($node, 'type') && property_exists($node, 'path')) {
-                        $nodeKey = $node->type . ' with value: \'' . $node->path->value . '\'';
+                        if ($node->path->value instanceof \Less_Tree_Quoted || property_exists($node->path->value, 'value')) {
+                            $nodeKey = $node->type . ' with value: \'' . $node->path->value->value . '\'';
+                        } else {
+                            $nodeKey = $node->type . ' with value: \'' . $node->path->value . '\'';
+                        }
                     } else {
                         $nodeKey = get_class($node);
                     }


### PR DESCRIPTION
Related to  https://github.com/magento/magento-semver/issues/73 - option 2, if you wish to see a more indepth writeup

The Less Analyzer class cannot handle Less files that import css as the object they convert into mean the $node->path->value is a Link_Tree_Quoted object and not a string castable value, so we add an additional check for if we are a CSS quoted file or if value is an object which contains another value and use that instead (In the off chance similar future issues may arise with new objects)